### PR TITLE
build: cache intermediate images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=weather-dash
-          cache-to: type=gha,mode=min,scope=weather-dash
+          cache-to: type=gha,mode=max,scope=weather-dash
           outputs: type=docker,oci-mediatypes=true,dest=/tmp/weather-dash.tar
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
@@ -147,7 +147,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=weather-dash
           cache-to: type=gha,mode=min,scope=weather-dash
-          outputs: type=docker,dest=/tmp/weather-dash.tar
           build-args: |
             BUILDTIME=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
             VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,10 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       - name: Test Docker compose
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDX_CACHE_FROM: type=gha
+          BUILDX_CACHE_TO: type=gha,mode=max
         run: |
           docker compose up -d
           docker compose down


### PR DESCRIPTION
Try to reduce the build time in the publish step by caching the intermediate layers so it does not try to rebuild the whole image.